### PR TITLE
Use a smaller representation for StringData

### DIFF
--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -1,0 +1,19 @@
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: miri, rust-src
+
+    - run: cargo miri test
+      env:
+        MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-disable-isolation

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -2,8 +2,9 @@ use std::fmt;
 use std::slice::Iter;
 
 use crate::{
-    Document, Name, NameData, StringData,
+    Document, Name, NameData,
     nodes::{Node, NodeKind},
+    strings::StringData,
 };
 
 impl<'doc, 'input> Node<'doc, 'input> {
@@ -63,6 +64,9 @@ pub struct AttributeData<'input> {
     pub name: NameData<'input>,
     pub value: StringData<'input>,
 }
+
+const _SIZE_OF_ATTRIBUTE_DATA: () =
+    assert!(size_of::<AttributeData<'static>>() == (3 + 2) * size_of::<usize>());
 
 #[derive(Clone)]
 pub struct Attributes<'doc, 'input> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,17 @@
-#![forbid(unsafe_code)]
-#![deny(missing_debug_implementations, missing_copy_implementations)]
+#![deny(
+    unsafe_code,
+    missing_debug_implementations,
+    missing_copy_implementations
+)]
 
 mod attributes;
 mod error;
 mod namespaces;
 mod nodes;
 mod parser;
+mod strings;
 mod tokenizer;
 
-use std::cmp::Ordering;
 use std::fmt;
 
 use attributes::AttributeData;
@@ -55,6 +58,9 @@ struct NameData<'input> {
     local: &'input str,
 }
 
+const _SIZE_OF_NAME_DATA: () =
+    assert!(size_of::<NameData<'static>>() == (1 + 2) * size_of::<usize>());
+
 impl<'input> NameData<'input> {
     fn get<'doc>(self, doc: &'doc Document) -> Name<'doc, 'input> {
         let namespace = self
@@ -65,41 +71,6 @@ impl<'input> NameData<'input> {
             namespace,
             local: self.local,
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-enum StringData<'input> {
-    Borrowed(&'input str),
-    Owned(Box<str>),
-}
-
-impl AsRef<str> for StringData<'_> {
-    fn as_ref(&self) -> &str {
-        match self {
-            Self::Borrowed(data) => data,
-            Self::Owned(data) => data,
-        }
-    }
-}
-
-impl PartialEq for StringData<'_> {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_ref().eq(other.as_ref())
-    }
-}
-
-impl Eq for StringData<'_> {}
-
-impl PartialOrd for StringData<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for StringData<'_> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.as_ref().cmp(other.as_ref())
     }
 }
 

--- a/src/namespaces.rs
+++ b/src/namespaces.rs
@@ -1,8 +1,8 @@
 use std::ops::Range;
 
 use crate::{
-    StringData,
     error::{ErrorKind, Result},
+    strings::StringData,
 };
 
 #[derive(Clone, Default)]
@@ -109,3 +109,6 @@ pub struct NamespaceData<'input> {
     pub name: Option<&'input str>,
     pub uri: StringData<'input>,
 }
+
+const _SIZE_OF_NAMESPACE_DATA: () =
+    assert!(size_of::<NamespaceData<'static>>() == (2 + 2) * size_of::<usize>());

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,0 +1,110 @@
+#![allow(unsafe_code)]
+
+use std::borrow::Cow;
+use std::cmp::Ordering;
+use std::marker::PhantomData;
+use std::mem::size_of;
+use std::ptr::{NonNull, slice_from_raw_parts_mut};
+
+#[derive(Debug)]
+pub struct StringData<'input> {
+    len: usize,
+    ptr: NonNull<u8>,
+    marker: PhantomData<Cow<'input, str>>,
+}
+
+const _SIZE_OF_STRING_DATA: () =
+    assert!(size_of::<StringData<'static>>() == 2 * size_of::<usize>());
+
+const TAG: usize = 1 << (usize::BITS - 1);
+
+impl<'input> StringData<'input> {
+    pub fn borrowed(val: &'input str) -> Self {
+        Self::from_raw_parts::<false>(val.len(), val.as_ptr() as *mut u8)
+    }
+
+    pub fn owned(val: Box<str>) -> Self {
+        Self::from_raw_parts::<true>(val.len(), Box::into_raw(val) as *mut u8)
+    }
+
+    fn from_raw_parts<const OWNED: bool>(mut len: usize, ptr: *mut u8) -> Self {
+        // This is implied by `len <= isize::MAX`, i.e. the maximum object and array size,
+        // c.f. <https://doc.rust-lang.org/stable/reference/types/numeric.html#r-type.numeric.int.size.isize>
+        // and <https://doc.rust-lang.org/1.68.0/reference/behavior-considered-undefined.html#dangling-pointers>.
+        debug_assert!(len & TAG == 0);
+
+        if OWNED {
+            len |= TAG;
+        }
+
+        Self {
+            len,
+            // SAFETY: We deconstructed a (boxed) string slice which is always non-null.
+            ptr: unsafe { NonNull::new_unchecked(ptr) },
+            marker: PhantomData,
+        }
+    }
+
+    fn is_owned(&self) -> bool {
+        self.len & TAG != 0
+    }
+
+    fn slice(&self) -> *mut str {
+        let ptr = self.ptr.as_ptr();
+        let len = self.len & !TAG;
+
+        slice_from_raw_parts_mut(ptr, len) as *mut str
+    }
+}
+
+impl Drop for StringData<'_> {
+    fn drop(&mut self) {
+        if self.is_owned() {
+            // SAFETY: Since the tag is set, we originally deconstructed a boxed string slice.
+            let _ = unsafe { Box::from_raw(self.slice()) };
+        }
+    }
+}
+
+impl Clone for StringData<'_> {
+    fn clone(&self) -> Self {
+        if self.is_owned() {
+            Self::owned(self.as_ref().into())
+        } else {
+            Self {
+                len: self.len,
+                ptr: self.ptr,
+                marker: self.marker,
+            }
+        }
+    }
+}
+
+impl AsRef<str> for StringData<'_> {
+    fn as_ref(&self) -> &str {
+        // SAFETY: We originally deconstructed a (boxed) string slice,
+        // i.e. a byte slice containing a UTF-8 representation of characters,
+        // c.f. <https://doc.rust-lang.org/reference/type-layout.html#str-layout>.
+        unsafe { &*self.slice() }
+    }
+}
+
+impl PartialEq for StringData<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_ref().eq(other.as_ref())
+    }
+}
+
+impl Eq for StringData<'_> {}
+
+impl PartialOrd for StringData<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StringData<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_ref().cmp(other.as_ref())
+    }
+}


### PR DESCRIPTION
This avoids the overhead of the enum tag by packing it into the length of the string slice which is bounded by isize::MAX.