### PR TITLE
Keep a stack of active namespaces pointing into deduplicated URI to simplify namespace handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "robinson"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "memchr",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 exclude = ["benches"]
 repository = "https://github.com/adamreichold/robinson"
 license = "MIT OR Apache-2.0"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2024"
 
 [features]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -35,6 +35,10 @@ impl<'input> Tokenizer<'input> {
         }
     }
 
+    pub(crate) fn element_depth(&self) -> u16 {
+        self.element_depth
+    }
+
     pub(crate) fn with_text<F, T>(&mut self, text: &mut &'input str, f: F) -> Result<T>
     where
         F: FnOnce(&mut Self) -> Result<T>,
@@ -474,7 +478,7 @@ impl<'input> Tokenizer<'input> {
             let space = self.try_space();
 
             if self.try_literal("/>") {
-                return parser.close_empty_element();
+                return parser.close_empty_element(self);
             } else if self.try_literal(">") {
                 self.element_depth = match self.element_depth.checked_add(1) {
                     Some(element_depth) => element_depth,
@@ -506,7 +510,7 @@ impl<'input> Tokenizer<'input> {
             None => return ErrorKind::UnexpectedCloseElement.into(),
         };
 
-        parser.close_element(prefix, local)
+        parser.close_element(self, prefix, local)
     }
 
     fn parse_attribute(&mut self) -> Result<(Option<&'input str>, &'input str, &'input str)> {

--- a/tests/inputs/overwrite_namespace.xml
+++ b/tests/inputs/overwrite_namespace.xml
@@ -1,0 +1,1 @@
+<foo:root xmlns:foo="http://bar"><foo:child xmlns:foo="http://baz"/><foo:child/></foo:root>

--- a/tests/outputs/overwrite_namespace.dbg
+++ b/tests/outputs/overwrite_namespace.dbg
@@ -1,0 +1,19 @@
+Ok(
+    Document {
+        root: Node {
+            children: [
+                Node {
+                    name: "{http://bar}root",
+                    children: [
+                        Node {
+                            name: "{http://baz}child",
+                        },
+                        Node {
+                            name: "{http://bar}child",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+)

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -47,6 +47,7 @@ test!(entity_reference_element);
 test!(invalid_reference_hexcode);
 test!(missing_root_element);
 test!(namespace_close_element);
+test!(overwrite_namespace);
 test!(public_doctype);
 test!(text);
 test!(text_entity_interleaved);


### PR DESCRIPTION
This also brings significant performance improvements for real world benchmarks:

```
name        main ns/iter  simpler ns/iter  diff ns/iter   diff %  speedup 
 attributes  2,189,945     2,208,766              18,821    0.86%   x 0.99 
 cdata       36,359        36,815                    456    1.25%   x 0.99 
 gigantic    248,230       247,865                  -365   -0.15%   x 1.00 
 huge        2,874,602     2,646,906            -227,696   -7.92%   x 1.09 
 large       1,186,256     1,063,369            -122,887  -10.36%   x 1.12 
 medium      297,110       274,253               -22,857   -7.69%   x 1.08 
 text        943,024       952,523                 9,499    1.01%   x 0.99 
 tiny        2,865         2,550                    -315  -10.99%   x 1.12
```