### PR TITLE
Implement searching for the end of names using portable SIMD.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
     missing_copy_implementations,
     unreachable_pub
 )]
+#![feature(portable_simd)]
 
 mod attributes;
 mod error;


### PR DESCRIPTION
Not yet viable as it requires a nightly toolchain, but SIMD appears to be the only way to improve `parse_qualname` as SWAR techniques alone do appear to be sufficient.

```
 name        main ns/iter  simd ns/iter  diff ns/iter   diff %  speedup 
 attributes  2,185,240     2,168,832          -16,408   -0.75%   x 1.01 
 cdata       37,631        34,448              -3,183   -8.46%   x 1.09 
 gigantic    238,561       241,712              3,151    1.32%   x 0.99 
 huge        1,986,094     1,751,409         -234,685  -11.82%   x 1.13 
 large       982,074       995,870             13,796    1.40%   x 0.99 
 medium      255,255       245,730             -9,525   -3.73%   x 1.04 
 text        953,638       937,252            -16,386   -1.72%   x 1.02 
 tiny        2,463         2,451                  -12   -0.49%   x 1.00 
```