### PR TITLE
Avoid runtime feature detection overhead for memchr invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "robinson"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "memchr",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 exclude = ["benches"]
 repository = "https://github.com/adamreichold/robinson"
 license = "MIT OR Apache-2.0"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2024"
 
 [features]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,13 +1,13 @@
 use std::ops::Range;
 
-use memchr::{memchr, memchr_iter, memchr2, memchr3};
-
 use crate::{
     Document, DocumentBuilder, NameData,
     attributes::AttributeData,
     error::{ErrorKind, Result},
     nodes::{ElementData, NodeData, NodeId},
-    strings::{StringBuf, StringsBuilder, cmp_names, cmp_opt_names},
+    strings::{
+        StringBuf, StringsBuilder, cmp_names, cmp_opt_names, memchr, memchr_count, memchr2, memchr3,
+    },
     tokenizer::{Reference, Tokenizer},
 };
 
@@ -59,8 +59,8 @@ struct Entity<'input> {
 
 impl<'input> Parser<'input> {
     fn new(text: &'input str) -> Result<Self> {
-        let nodes = memchr_iter(b'<', text.as_bytes()).count();
-        let attributes = memchr_iter(b'=', text.as_bytes()).count();
+        let nodes = memchr_count(b'<', text.as_bytes());
+        let attributes = memchr_count(b'=', text.as_bytes());
 
         let mut doc = DocumentBuilder {
             nodes: Vec::with_capacity(nodes),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,11 +1,9 @@
 use std::mem::swap;
 
-use memchr::{memchr, memmem::Finder};
-
 use crate::{
     error::{Error, ErrorKind, Result},
     parser::Parser,
-    strings::{split_first, split_once},
+    strings::{Finder, memchr, split_first, split_once},
 };
 
 pub(crate) struct Tokenizer<'input> {


### PR DESCRIPTION
Since we do a lot of memchr invocations over relatively short distances, the cost of runtime feature detection is measurable and avoiding it can save a few percent of runtime:

```
 name        main ns/iter  static ns/iter  diff ns/iter   diff %  speedup 
 attributes  2,162,710     1,933,327           -229,383  -10.61%   x 1.12 
 cdata       34,256        31,204                -3,052   -8.91%   x 1.10 
 gigantic    240,139       237,314               -2,825   -1.18%   x 1.01 
 huge        1,707,169     1,661,185            -45,984   -2.69%   x 1.03 
 large       973,644       938,957              -34,687   -3.56%   x 1.04 
 medium      242,396       225,557              -16,839   -6.95%   x 1.07 
 text        949,866       882,003              -67,863   -7.14%   x 1.08 
 tiny        2,429         2,333                    -96   -3.95%   x 1.04 
```