### PR TITLE
 Avoid runtime feature detection overhead for memchr invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "robinson"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "memchr",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 exclude = ["benches"]
 repository = "https://github.com/adamreichold/robinson"
 license = "MIT OR Apache-2.0"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2024"
 
 [features]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,13 +1,13 @@
 use std::ops::Range;
 
-use memchr::{memchr, memchr_iter, memchr2, memchr3};
-
 use crate::{
     Document, DocumentBuilder, NameData,
     attributes::AttributeData,
     error::{ErrorKind, Result},
     nodes::{ElementData, NodeData, NodeId},
-    strings::{StringBuf, StringsBuilder, cmp_names, cmp_opt_names},
+    strings::{
+        StringBuf, StringsBuilder, cmp_names, cmp_opt_names, memchr, memchr_count, memchr2, memchr3,
+    },
     tokenizer::{Reference, Tokenizer},
 };
 
@@ -60,8 +60,8 @@ struct Entity<'input> {
 
 impl<'input> Parser<'input> {
     fn new(text: &'input str) -> Result<Self> {
-        let nodes = memchr_iter(b'<', text.as_bytes()).count();
-        let attributes = memchr_iter(b'=', text.as_bytes()).count();
+        let nodes = memchr_count(b'<', text.as_bytes());
+        let attributes = memchr_count(b'=', text.as_bytes());
 
         let mut doc = DocumentBuilder {
             nodes: Vec::with_capacity(nodes),

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -2,8 +2,6 @@
 
 use std::mem::take;
 
-use memchr::memchr;
-
 use crate::{
     error::{ErrorKind, Result},
     nodes::NodeId,
@@ -166,6 +164,76 @@ impl<'doc, 'input> StringBuf<'doc, 'input> {
 
         Ok(id)
     }
+}
+
+#[inline]
+pub(crate) fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    let pos =
+        unsafe { memchr::arch::x86_64::avx2::memchr::One::new_unchecked(needle).find(haystack) };
+
+    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx2")))]
+    let pos =
+        unsafe { memchr::arch::x86_64::sse2::memchr::One::new_unchecked(needle).find(haystack) };
+
+    #[cfg(not(target_arch = "x86_64"))]
+    let pos = memchr::arch::all::memchr::One::new(needle).find(haystack);
+
+    pos
+}
+
+#[inline]
+pub(crate) fn memchr_count(needle: u8, haystack: &[u8]) -> usize {
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    let cnt =
+        unsafe { memchr::arch::x86_64::avx2::memchr::One::new_unchecked(needle).count(haystack) };
+
+    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx2")))]
+    let cnt =
+        unsafe { memchr::arch::x86_64::sse2::memchr::One::new_unchecked(needle).count(haystack) };
+
+    #[cfg(not(target_arch = "x86_64"))]
+    let cnt = memchr::arch::all::memchr::One::new(needle).count(haystack);
+
+    cnt
+}
+
+#[inline]
+pub(crate) fn memchr2(needle1: u8, needle2: u8, haystack: &[u8]) -> Option<usize> {
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    let pos = unsafe {
+        memchr::arch::x86_64::avx2::memchr::Two::new_unchecked(needle1, needle2).find(haystack)
+    };
+
+    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx2")))]
+    let pos = unsafe {
+        memchr::arch::x86_64::sse2::memchr::Two::new_unchecked(needle1, needle2).find(haystack)
+    };
+
+    #[cfg(not(target_arch = "x86_64"))]
+    let pos = memchr::arch::all::memchr::Two::new(needle1, needle2).find(haystack);
+
+    pos
+}
+
+#[inline]
+pub(crate) fn memchr3(needle1: u8, needle2: u8, needle3: u8, haystack: &[u8]) -> Option<usize> {
+    #[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
+    let pos = unsafe {
+        memchr::arch::x86_64::avx2::memchr::Three::new_unchecked(needle1, needle2, needle3)
+            .find(haystack)
+    };
+
+    #[cfg(all(target_arch = "x86_64", not(target_feature = "avx2")))]
+    let pos = unsafe {
+        memchr::arch::x86_64::sse2::memchr::Three::new_unchecked(needle1, needle2, needle3)
+            .find(haystack)
+    };
+
+    #[cfg(not(target_arch = "x86_64"))]
+    let pos = memchr::arch::all::memchr::Three::new(needle1, needle2, needle3).find(haystack);
+
+    pos
 }
 
 #[inline]

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -253,14 +253,26 @@ pub(crate) fn split_first<const N: usize>(str_: &str, bytes: [u8; N]) -> Option<
 }
 
 #[inline]
-pub(crate) fn split_once(str_: &str, delim: u8) -> Option<(&str, &str)> {
+pub(crate) fn split_until(str_: &str, end: u8) -> (&str, &str) {
+    assert!(end.is_ascii());
+
+    let pos = memchr(end, str_.as_bytes()).unwrap_or(str_.len());
+
+    // SAFETY: `end` is an ASCII character hence at a character boundary.
+    let before = unsafe { str_.get_unchecked(..pos) };
+    let after = unsafe { str_.get_unchecked(pos..) };
+
+    (before, after)
+}
+
+#[inline]
+pub(crate) fn split_around(str_: &str, delim: u8) -> Option<(&str, &str)> {
     assert!(delim.is_ascii());
 
     let pos = memchr(delim, str_.as_bytes())?;
 
-    // SAFETY: `delim` is a ASCII character hence preceeded by a character boundary.
+    // SAFETY: `delim` is an ASCII character hence surrounded by character boundaries.
     let before = unsafe { str_.get_unchecked(..pos) };
-    // SAFETY: `delim` is a ASCII character hence followed by a character boundary.
     let after = unsafe { str_.get_unchecked(pos + 1..) };
 
     Some((before, after))

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,11 +1,11 @@
 use std::mem::swap;
 
-use memchr::{memchr, memmem::Finder};
+use memchr::memmem::Finder;
 
 use crate::{
     error::{Error, ErrorKind, Result},
     parser::Parser,
-    strings::{split_first, split_once},
+    strings::{memchr, split_first, split_once},
 };
 
 pub(crate) struct Tokenizer<'input> {


### PR DESCRIPTION
Since we do a lot of memchr invocations over relatively short distances, the cost of runtime feature detection is measurable and avoiding it can save a few percent of runtime:

```
 name        main ns/iter  static ns/iter  diff ns/iter   diff %  speedup 
 attributes  2,162,710     1,933,327           -229,383  -10.61%   x 1.12 
 cdata       34,256        31,204                -3,052   -8.91%   x 1.10 
 gigantic    240,139       237,314               -2,825   -1.18%   x 1.01 
 huge        1,707,169     1,661,185            -45,984   -2.69%   x 1.03 
 large       973,644       938,957              -34,687   -3.56%   x 1.04 
 medium      242,396       225,557              -16,839   -6.95%   x 1.07 
 text        949,866       882,003              -67,863   -7.14%   x 1.08 
 tiny        2,429         2,333                    -96   -3.95%   x 1.04 
```