### PR TITLE
Provide an optimized routine to estimate the number of nodes and attributes in a single pass.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "robinson"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "memchr",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 exclude = ["benches"]
 repository = "https://github.com/adamreichold/robinson"
 license = "MIT OR Apache-2.0"
-version = "0.5.8"
+version = "0.5.9"
 edition = "2024"
 
 [features]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,7 +6,8 @@ use crate::{
     error::{ErrorKind, Result},
     nodes::{ElementData, NodeData, NodeId},
     strings::{
-        StringBuf, StringsBuilder, cmp_names, cmp_opt_names, memchr, memchr_count, memchr2, memchr3,
+        StringBuf, StringsBuilder, cmp_names, cmp_opt_names, memchr, memchr2, memchr2_count,
+        memchr3,
     },
     tokenizer::{Reference, Tokenizer},
 };
@@ -60,8 +61,7 @@ struct Entity<'input> {
 
 impl<'input> Parser<'input> {
     fn new(text: &'input str) -> Result<Self> {
-        let nodes = memchr_count(b'<', text.as_bytes());
-        let attributes = memchr_count(b'=', text.as_bytes());
+        let (nodes, attributes) = memchr2_count(b'<', b'=', text.as_bytes());
 
         let mut doc = DocumentBuilder {
             nodes: Vec::with_capacity(nodes),

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -5,7 +5,7 @@ use memchr::memmem::Finder;
 use crate::{
     error::{Error, ErrorKind, Result},
     parser::Parser,
-    strings::{split_around, split_first, split_until},
+    strings::{split_after, split_at, split_first},
 };
 
 pub(crate) struct Tokenizer<'input> {
@@ -356,7 +356,7 @@ impl<'input> Tokenizer<'input> {
     fn parse_text(&mut self, parser: &mut Parser<'input>) -> Result {
         debug_assert!(!self.text.is_empty());
 
-        let (text, rest) = split_until(self.text, b'<');
+        let (text, rest) = split_at(self.text, b'<');
         self.text = rest;
 
         parser.append_text(self, text)
@@ -449,7 +449,7 @@ impl<'input> Tokenizer<'input> {
     fn parse_quoted(&mut self) -> Result<&'input str> {
         let quote = self.expect_quote()?;
 
-        let Some((quoted, rest)) = split_around(self.text, quote) else {
+        let Some((quoted, rest)) = split_after(self.text, quote) else {
             return ErrorKind::ExpectedQuote.into();
         };
         self.text = rest;
@@ -514,7 +514,7 @@ impl<'input> Tokenizer<'input> {
     }
 
     pub(crate) fn parse_reference(&mut self) -> Result<Reference<'input>> {
-        let Some((value, rest)) = split_around(self.text, b';') else {
+        let Some((value, rest)) = split_after(self.text, b';') else {
             return ErrorKind::ExpectedLiteral(";").into();
         };
         self.text = rest;


### PR DESCRIPTION
```
 name        main ns/iter  memchr2_count ns/iter  diff ns/iter  diff %  speedup 
 attributes  1,034,603     1,041,431                     6,828   0.66%   x 0.99 
 cdata       16,859        16,585                         -274  -1.63%   x 1.02 
 gigantic    131,181       124,410                      -6,771  -5.16%   x 1.05 
 huge        880,177       874,585                      -5,592  -0.64%   x 1.01 
 large       505,890       492,064                     -13,826  -2.73%   x 1.03 
 medium      123,118       122,540                        -578  -0.47%   x 1.00 
 text        478,833       463,619                     -15,214  -3.18%   x 1.03 
 tiny        1,225         1,226                             1   0.08%   x 1.00 
```